### PR TITLE
role based deployments supporting multiple accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Authorized users can perform drag-n-drop deployments without understanding the t
 
 ### Goals ###
 
-* Expose portal to deploy and monitor AWS resources
+* Create portal to deploy and monitor AWS resources
 * Enable consitent application versioning across multiple AWS resource types
 * Secure deployments by application and/or environment
 * Allow simple drag-n-drop deployments
 * Provide high level environment resource notifications and troubleshooting
 * Make projects searchable for quick access to details, versions, and documentation
-* Improve resource monitoring for integration partners
+* Improve resource monitoring and interaction for integration partners
 * Support authetication with any OAuth2 API
 * Enable deployment workflow innovation (avoid third-party timelines)
 * Centralize navigation to project resources by linking to scrum boards, config tools, and project documentation
@@ -26,6 +26,7 @@ Authorized users can perform drag-n-drop deployments without understanding the t
 * Duplicate AWS console functionality
 * Implement continuous integration features
 * Display or modify infrastructure
+* Replace existing CI/CD piplines
 
 </details>
 
@@ -35,8 +36,9 @@ Authorized users can perform drag-n-drop deployments without understanding the t
 
 || Fargate Service | Fargate Task | Lambda Function | S3 Contents ||
 |---|---|---|---|---|---|
+|Multiple Accounts|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|Manages AWS resources accross multiple accounts with a single portal. |
 |Authentication|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|Supports OAuth2 for authenticating users. |
-|Authorization|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|Supports user permissions for editing and deploying environment instances. |
+|Authorization|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|Supports role based user permissions for editing and deploying environment instances. |
 |View Instance Version|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|Provides a view into an instance's deployed version details.|
 |View Instance Status|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|Provides a view into an instances status showing deployments in progress, erroring containers or lambdas, and scaling services and tasks.|
 |View Instance Tasks|:white_check_mark:|:white_check_mark:|||Provides a view into what version of a service's tasks are starting or stopping at any given moment.|
@@ -105,7 +107,7 @@ Supported Browser: Chrome
 <details>
   <summary>Architecture</summary>
 
-The portal functions as a passive monitoring and active deployment platform. The architecture diagram is divided into two areas, monitoring and user actions.
+The portal functions as a passive monitoring and active deployment platform. The architecture diagram is divided into two sections, monitoring and user actions.
 
 ![uDeploy Architecture](/image/architecture.png "uDeploy Architecture")
 

--- a/component/app/copy.go
+++ b/component/app/copy.go
@@ -65,6 +65,8 @@ func (i Instance) Copy() Instance {
 	n := Instance{
 		Cluster:          i.Cluster,
 		Service:          i.Service,
+		Role:             i.Role,
+		RepositoryRole:   i.RepositoryRole,
 		EventRule:        i.EventRule,
 		Repository:       i.Repository,
 		FunctionName:     i.FunctionName,

--- a/component/app/model_app.go
+++ b/component/app/model_app.go
@@ -196,7 +196,7 @@ func DefinitionFrom(td *ecs.TaskDefinition, imageTagRegEx string) Definition {
 	version, build := version.Extract(*td.ContainerDefinitions[0].Image, imageTagRegEx)
 
 	def := Definition{
-		ID: *td.Family,
+		ID: *td.TaskDefinitionArn,
 
 		Version:  version,
 		Build:    build,

--- a/component/app/model_app.go
+++ b/component/app/model_app.go
@@ -196,7 +196,7 @@ func DefinitionFrom(td *ecs.TaskDefinition, imageTagRegEx string) Definition {
 	version, build := version.Extract(*td.ContainerDefinitions[0].Image, imageTagRegEx)
 
 	def := Definition{
-		ID: *td.TaskDefinitionArn,
+		ID: (*td.TaskDefinitionArn)[0:strings.LastIndex(*td.TaskDefinitionArn, ":")],
 
 		Version:  version,
 		Build:    build,

--- a/component/app/model_instance.go
+++ b/component/app/model_instance.go
@@ -11,6 +11,7 @@ import (
 // InstanceView ...
 type InstanceView struct {
 	// Database Fields
+	Role          string `json:"role"`
 	Name          string `json:"name"`
 	Order         int    `json:"order"`
 	Cluster       string `json:"cluster,omitempty"`
@@ -25,10 +26,11 @@ type InstanceView struct {
 	S3RegistryBucket string `json:"s3RegistryBucket,omitempty"`
 	S3RegistryPrefix string `json:"s3RegistryPrefix,omitempty"`
 
-	Repository    string   `json:"repository,omitempty"`
-	DeployCode    string   `json:"deployCode"`
-	AutoPropagate bool     `json:"autoPropagate"`
-	Task          TaskView `json:"task"`
+	Repository     string   `json:"repository,omitempty"`
+	RepositoryRole string   `json:"repositoryRole,omitempty"`
+	DeployCode     string   `json:"deployCode"`
+	AutoPropagate  bool     `json:"autoPropagate"`
+	Task           TaskView `json:"task"`
 
 	// Calculated Fields
 	FormattedVersion string `json:"formattedVersion"`
@@ -70,6 +72,8 @@ type ContainerView struct {
 // Instance ...
 type Instance struct {
 	// Database Fields
+	Role string `json:"role" bson:"role"`
+
 	Order   int    `json:"order" bson:"order"`
 	Cluster string `json:"cluster,omitempty" bson:"cluster"`
 	Service string `json:"service,omitempty" bson:"service"`
@@ -85,12 +89,13 @@ type Instance struct {
 	S3RegistryBucket string `json:"s3RegistryBucket,omitempty" bson:"s3RegistryBucket"`
 	S3RegistryPrefix string `json:"s3RegistryPrefix,omitempty" bson:"s3RegistryPrefix"`
 
-	Repository    string `json:"repository,omitempty" bson:"repository"`
-	DeployCode    string `json:"deployCode" bson:"deployCode"`
-	AutoPropagate bool   `json:"autoPropagate" bson:"autoPropagate"`
-	AutoScale     bool   `json:"autoScale"`
-	Task          Task   `json:"task" bson:"taskDefinition"`
-	Links         []Link `json:"links" bson:"links"`
+	Repository     string `json:"repository,omitempty" bson:"repository"`
+	RepositoryRole string `json:"repositoryRole,omitempty" bson:"repositoryRole"`
+	DeployCode     string `json:"deployCode" bson:"deployCode"`
+	AutoPropagate  bool   `json:"autoPropagate" bson:"autoPropagate"`
+	AutoScale      bool   `json:"autoScale"`
+	Task           Task   `json:"task" bson:"taskDefinition"`
+	Links          []Link `json:"links" bson:"links"`
 
 	// Calculated Fields
 	CurrentState  State `json:"-" bson:"-"`
@@ -181,10 +186,12 @@ type Link struct {
 func (v InstanceView) ToBusiness() Instance {
 
 	i := Instance{
+		Role:             v.Role,
 		Cluster:          v.Cluster,
 		Service:          v.Service,
 		EventRule:        v.EventRule,
 		Repository:       v.Repository,
+		RepositoryRole:   v.RepositoryRole,
 		FunctionName:     v.FunctionName,
 		FunctionAlias:    v.FunctionAlias,
 		S3Bucket:         v.S3Bucket,
@@ -228,6 +235,7 @@ func (i Instance) ToView(name string, appClaim user.AppClaim) InstanceView {
 		CronExpression:   i.Task.CronExpression,
 		CronEnabled:      i.Task.CronEnabled,
 		Claims:           map[string]bool{},
+		Role:             i.Role,
 		Cluster:          i.Cluster,
 		Service:          i.Service,
 		EventRule:        i.EventRule,
@@ -239,6 +247,7 @@ func (i Instance) ToView(name string, appClaim user.AppClaim) InstanceView {
 		S3RegistryBucket: i.S3RegistryBucket,
 		S3RegistryPrefix: i.S3RegistryPrefix,
 		Repository:       i.Repository,
+		RepositoryRole:   i.RepositoryRole,
 		DeployCode:       i.DeployCode,
 		AutoPropagate:    i.AutoPropagate,
 		AutoScale:        i.AutoScale,

--- a/component/build/registry.go
+++ b/component/build/registry.go
@@ -46,7 +46,7 @@ func GetBuilds(c echo.Context) error {
 
 	switch apps[0].Type {
 	case app.AppTypeService, app.AppTypeScheduledTask:
-		builds, err = task.ListDefinitions(sourceRegistry.Task)
+		builds, err = task.ListDefinitions(sourceRegistry)
 		if err != nil {
 			return err
 		}

--- a/component/integration/aws/config/merge.go
+++ b/component/integration/aws/config/merge.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// Merge creates and merges a list of configs into a single
+// AWS session allowing the session to assume multiple roles.
+func Merge(roles []string, s *session.Session) []*aws.Config {
+	configs := []*aws.Config{aws.NewConfig()}
+
+	for _, r := range roles {
+		if len(r) == 0 {
+			continue
+		}
+
+		creds := stscreds.NewCredentials(s, r)
+
+		configs = append(configs, aws.NewConfig().WithCredentials(creds))
+	}
+
+	s.Config.MergeIn(configs...)
+
+	return configs
+}

--- a/component/integration/aws/ecr/list.go
+++ b/component/integration/aws/ecr/list.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/turnerlabs/udeploy/component/app"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 	"github.com/turnerlabs/udeploy/component/version"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,7 +14,7 @@ import (
 
 // ListDefinitions ...
 func ListDefinitions(registry app.Instance) (map[string]app.Definition, error) {
-	images, err := List(registry.Repo())
+	images, err := List(registry)
 	if err != nil {
 		return map[string]app.Definition{}, err
 	}
@@ -42,8 +43,15 @@ func ListDefinitions(registry app.Instance) (map[string]app.Definition, error) {
 }
 
 // List ...
-func List(repo string) ([]*ecr.ImageIdentifier, error) {
-	svc := ecr.New(session.New())
+func List(i app.Instance) ([]*ecr.ImageIdentifier, error) {
+
+	repo := i.Repo()
+
+	session := session.New()
+
+	config.Merge([]string{i.RepositoryRole}, session)
+
+	svc := ecr.New(session)
 
 	input := &ecr.ListImagesInput{
 		RepositoryName: aws.String(repo[strings.Index(repo, "/")+1 : len(repo)]),

--- a/component/integration/aws/event/populate.go
+++ b/component/integration/aws/event/populate.go
@@ -8,19 +8,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 	"github.com/turnerlabs/udeploy/component/integration/aws/task"
 )
 
 // Populate ...
 func Populate(instances map[string]app.Instance) (map[string]app.Instance, error) {
-	sesssion := session.New()
-
-	evtSvc := cloudwatchevents.New(sesssion)
-	ecsSvc := ecs.New(sesssion)
 
 	populated := map[string]app.Instance{}
 
 	for name, i := range instances {
+		session := session.New()
+
+		config.Merge([]string{i.Role}, session)
+
+		evtSvc := cloudwatchevents.New(session)
+		ecsSvc := ecs.New(session)
 
 		i, state, err := populateInst(i, ecsSvc, evtSvc)
 		if err != nil {

--- a/component/integration/aws/event/scale.go
+++ b/component/integration/aws/event/scale.go
@@ -11,14 +11,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 	"github.com/turnerlabs/udeploy/component/integration/aws/task"
 	sess "github.com/turnerlabs/udeploy/component/session"
 )
 
 func Scale(ctx context.Context, instance app.Instance, desiredCount int64, restart bool) error {
 	usr := ctx.Value(sess.ContextKey("user")).(user.User)
-	evtSvc := cloudwatchevents.New(session.New())
-	ecsSvc := ecs.New(session.New())
+
+	session := session.New()
+
+	config.Merge([]string{instance.Role}, session)
+
+	evtSvc := cloudwatchevents.New(session)
+	ecsSvc := ecs.New(session)
+
 	input := &cloudwatchevents.ListTargetsByRuleInput{
 		Rule: &instance.EventRule,
 	}

--- a/component/integration/aws/lambda/alarm.go
+++ b/component/integration/aws/lambda/alarm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/turnerlabs/udeploy/component/cfg"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -11,8 +12,12 @@ import (
 )
 
 // DeleteAlarm ...
-func DeleteAlarm(functionName string) error {
-	svc := cloudwatch.New(session.New())
+func DeleteAlarm(functionName, role string) error {
+	session := session.New()
+
+	config.Merge([]string{role}, session)
+
+	svc := cloudwatch.New(session)
 
 	_, err := svc.DeleteAlarms(&cloudwatch.DeleteAlarmsInput{
 		AlarmNames: aws.StringSlice([]string{buildAlarmName(functionName)}),
@@ -22,9 +27,12 @@ func DeleteAlarm(functionName string) error {
 }
 
 // UpsertAlarm ...
-func UpsertAlarm(functionName, functionAlias, snsTopicArn string) error {
+func UpsertAlarm(functionName, functionAlias, role, snsTopicArn string) error {
+	session := session.New()
 
-	svc := cloudwatch.New(session.New())
+	config.Merge([]string{role}, session)
+
+	svc := cloudwatch.New(session)
 
 	_, err := svc.PutMetricAlarm(&cloudwatch.PutMetricAlarmInput{
 		AlarmName:          aws.String(buildAlarmName(functionName)),

--- a/component/integration/aws/lambda/deploy.go
+++ b/component/integration/aws/lambda/deploy.go
@@ -195,12 +195,15 @@ func deployConfig(source, target app.Instance, opts task.DeployOptions, svc *lam
 	input := mapConfiguration(*currentFunc.Configuration)
 
 	for _, key := range target.Task.CloneEnvVars {
-		if value, found := sourceFunc.Configuration.Environment.Variables[key]; found {
-			input.Environment.Variables[key] = value
+		if sourceFunc.Configuration.Environment != nil {
+			if value, found := sourceFunc.Configuration.Environment.Variables[key]; found {
+				input.Environment.Variables[key] = value
+			}
 		}
 	}
 
 	if opts.Override {
+		input.Environment = &lambda.Environment{}
 		input.Environment.SetVariables(aws.StringMap(opts.Environment))
 	}
 

--- a/component/integration/aws/lambda/list.go
+++ b/component/integration/aws/lambda/list.go
@@ -45,9 +45,11 @@ func ListDefinitions(instance app.Instance) (map[string]app.Definition, error) {
 		}
 
 		env := map[string]string{}
-		for k, v := range funcVersion.Environment.Variables {
-			value := *v
-			env[k] = value
+		if funcVersion.Environment != nil {
+			for k, v := range funcVersion.Environment.Variables {
+				value := *v
+				env[k] = value
+			}
 		}
 
 		def := app.Definition{

--- a/component/integration/aws/lambda/list.go
+++ b/component/integration/aws/lambda/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/turnerlabs/udeploy/component/app"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 )
 
 // ISO8601 time format
@@ -18,7 +19,11 @@ const ISO8601 = "2006-01-02T15:04:05-0700"
 // ListDefinitions ...
 func ListDefinitions(instance app.Instance) (map[string]app.Definition, error) {
 
-	svc := lambda.New(session.New())
+	session := session.New()
+
+	config.Merge([]string{instance.Role}, session)
+
+	svc := lambda.New(session)
 	ver, err := listVersions(svc, instance.FunctionName, "", []*lambda.FunctionConfiguration{})
 	if err != nil {
 		return nil, err

--- a/component/integration/aws/lambda/populate.go
+++ b/component/integration/aws/lambda/populate.go
@@ -71,9 +71,12 @@ func populateInst(i app.Instance, svc *lambda.Lambda, cwsvc *cloudwatch.CloudWat
 	i.Task.Definition.Description = fmt.Sprintf("%s.%s", version, build)
 
 	env := map[string]string{}
-	for k, v := range fo.Configuration.Environment.Variables {
-		value := *v
-		env[k] = value
+
+	if fo.Configuration.Environment != nil {
+		for k, v := range fo.Configuration.Environment.Variables {
+			value := *v
+			env[k] = value
+		}
 	}
 
 	i.Task.Definition.Environment = env

--- a/component/integration/aws/lambda/scale.go
+++ b/component/integration/aws/lambda/scale.go
@@ -1,8 +1,10 @@
 package lambda
 
 import (
-	"github.com/turnerlabs/udeploy/component/app"
 	"context"
+
+	"github.com/turnerlabs/udeploy/component/app"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -16,7 +18,11 @@ func Scale(ctx context.Context, instance app.Instance, desiredCount int64) error
 		return nil
 	}
 
-	svc := lambda.New(session.New())
+	session := session.New()
+
+	config.Merge([]string{instance.Role}, session)
+
+	svc := lambda.New(session)
 
 	ao, err := svc.GetAliasWithContext(ctx, &lambda.GetAliasInput{
 		Name:         aws.String(instance.FunctionAlias),

--- a/component/integration/aws/s3/populate.go
+++ b/component/integration/aws/s3/populate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 	"github.com/turnerlabs/udeploy/component/version"
 
 	"github.com/turnerlabs/udeploy/component/app"
@@ -20,12 +21,13 @@ import (
 // Populate ...
 func Populate(instances map[string]app.Instance) (map[string]app.Instance, error) {
 
-	sess := session.New()
-
-	svc := s3.New(sess)
-	downloader := s3manager.NewDownloader(sess)
-
 	for key, instance := range instances {
+		sess := session.New()
+
+		config.Merge([]string{instance.Role}, sess)
+
+		svc := s3.New(sess)
+		downloader := s3manager.NewDownloader(sess)
 
 		i, state, err := populateInst(instance, svc, downloader)
 		if err != nil {

--- a/component/integration/aws/service/deploy.go
+++ b/component/integration/aws/service/deploy.go
@@ -1,18 +1,23 @@
 package service
 
 import (
-	"github.com/turnerlabs/udeploy/component/app"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/turnerlabs/udeploy/component/app"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 	"github.com/turnerlabs/udeploy/component/integration/aws/task"
 )
 
 // Deploy ...
 func Deploy(source app.Instance, target app.Instance, revision int64, opts task.DeployOptions) error {
 
-	svc := ecs.New(session.New())
- 
+	session := session.New()
+
+	config.Merge([]string{target.Role}, session)
+
+	svc := ecs.New(session)
+
 	newOutput, err := task.Deploy(source, target, revision, source.Version(), opts)
 	if err != nil {
 		return err

--- a/component/integration/aws/service/scale.go
+++ b/component/integration/aws/service/scale.go
@@ -1,16 +1,21 @@
 package service
 
 import (
-	"github.com/turnerlabs/udeploy/component/app"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/turnerlabs/udeploy/component/app"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 )
 
 // Scale ...
 func Scale(instance app.Instance, desiredCount int64, restart bool) error {
 
-	svc := ecs.New(session.New())
+	session := session.New()
+
+	config.Merge([]string{instance.Role}, session)
+
+	svc := ecs.New(session)
 
 	_, err := svc.UpdateService(
 		&ecs.UpdateServiceInput{
@@ -21,9 +26,5 @@ func Scale(instance app.Instance, desiredCount int64, restart bool) error {
 		},
 	)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/component/integration/aws/sqs/rules.go
+++ b/component/integration/aws/sqs/rules.go
@@ -192,5 +192,5 @@ type eventMessageDetail struct {
 }
 
 func (d eventMessageDetail) taskDefinition() string {
-	return d.TaskDefinitionArn
+	return d.TaskDefinitionArn[0:strings.LastIndex(d.TaskDefinitionArn, ":")]
 }

--- a/component/integration/aws/sqs/rules.go
+++ b/component/integration/aws/sqs/rules.go
@@ -192,5 +192,5 @@ type eventMessageDetail struct {
 }
 
 func (d eventMessageDetail) taskDefinition() string {
-	return d.TaskDefinitionArn[strings.Index(d.TaskDefinitionArn, "/")+1 : strings.LastIndex(d.TaskDefinitionArn, ":")]
+	return d.TaskDefinitionArn
 }

--- a/component/integration/aws/task/deploy.go
+++ b/component/integration/aws/task/deploy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/turnerlabs/udeploy/component/app"
+	"github.com/turnerlabs/udeploy/component/integration/aws/config"
 	"github.com/turnerlabs/udeploy/component/version"
 )
 
@@ -27,7 +28,11 @@ func (do DeployOptions) DeployImage() bool {
 
 // Deploy ...
 func Deploy(source app.Instance, target app.Instance, sourceRevision int64, sourceVersion string, opts DeployOptions) (td *ecs.TaskDefinition, err error) {
-	svc := ecs.New(session.New())
+	session := session.New()
+
+	config.Merge([]string{source.Role, target.Role}, session)
+
+	svc := ecs.New(session)
 
 	sourceTaskArn := fmt.Sprintf("%s:%d", source.Task.Family, sourceRevision)
 	sourceOutput, err := svc.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -104,4 +104,23 @@ $ cstore push infrastructure/portals/prod/.env -s aws-parameter -t prod
 
 When prompted, set context to `udeploy` and the KMS Key ID to the `kms_key_id` from the Terraform output.
 
- 
+ ### 9. Link Other AWS Accounts (optional) ### 
+
+ To deploy resources accross multiple AWS accounts, provide permissions to each additional AWS account the portal should control. 
+
+ Duplicate the folder `infrastructure/accounts/dev` for each account `infrastructure/accounts/{{ACCOUNT_IDENTIFIER}}` and following the intructions.
+
+ Replace `{{TOKENS}}` in `infrastructure/accounts/{{ACCOUNT_IDENTIFIER}}/terraform.tfvars`.
+```bash
+$ terraform init -var-file=infrastructure/accounts/{{ACCOUNT_IDENTIFIER}}/terraform.tfvars  infrastructure/accounts/{{ACCOUNT_IDENTIFIER}} 
+$ terraform apply -var-file=infrastructure/accounts/{{ACCOUNT_IDENTIFIER}}/terraform.tfvars  infrastructure/accounts/{{ACCOUNT_IDENTIFIER}}
+```
+
+Update `linked_account_ids` in [infrastructure/base/terraform.tfvars](/infrastructure/base/terraform.tfvars) with account ids of all linked accounts.
+
+```
+$ terraform apply -var-file=infrastructure/base/terraform.tfvars  infrastructure/base
+```
+
+
+

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/aws/aws-sdk-go v1.17.3 h1:KBXxg7Jh0TxE5zmpNB2DwKmJeDUqh0O6jhy25TuYOmc=
 github.com/aws/aws-sdk-go v1.17.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.40 h1:mojGvleHfFV7M5KBID5XjCeUHwDM5KEVS/fx3oriDZ0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/infrastructure/accounts/dev/main.tf
+++ b/infrastructure/accounts/dev/main.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+  version = ">= 1.46.0"
+  region  = var.region
+  profile = var.aws_profile
+}
+
+module "dev" {
+    source = "../../modules/link"
+
+    region = var.region
+
+    app = var.app
+    environment = var.environment
+
+    portal_account_id = var.portal_account_id
+}
+
+output "account_id" {
+  value = module.dev.account_id
+}
+
+output "role_arn" {
+  value = module.dev.role_arn
+}

--- a/infrastructure/accounts/dev/terraform.tfvars
+++ b/infrastructure/accounts/dev/terraform.tfvars
@@ -1,0 +1,6 @@
+aws_profile = "{{AWS_PROFILE}}"
+
+app = "udeploy"
+environment = "dev"
+
+portal_account_id = {{AWS_ACCOUNT_ID}}

--- a/infrastructure/accounts/dev/variables.tf
+++ b/infrastructure/accounts/dev/variables.tf
@@ -1,0 +1,12 @@
+variable "aws_profile" {
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "app" {}
+
+variable "environment" {}
+
+variable "portal_account_id" {}

--- a/infrastructure/base/events.tf
+++ b/infrastructure/base/events.tf
@@ -1,0 +1,6 @@
+resource "aws_cloudwatch_event_permission" "linked_accounts" {
+  count = length(var.linked_account_ids)
+
+  principal  = var.linked_account_ids[count.index]
+  statement_id = "LinkedAccountEvents-${count.index}"
+}

--- a/infrastructure/base/terraform.tfvars
+++ b/infrastructure/base/terraform.tfvars
@@ -22,3 +22,7 @@ tags = {
   product          = "udeploy"
   project          = "udeploy"
 }
+
+# Allow other AWS accounts to publish events
+# to this account for app status updates
+linked_account_ids = []

--- a/infrastructure/base/variables.tf
+++ b/infrastructure/base/variables.tf
@@ -34,3 +34,9 @@ variable "tags" {
 
 variable "domain" {
 }
+
+# Allow other AWS accounts to publish events
+# to this account for app status updates
+variable "linked_account_ids" {
+  type        = list(string)
+}

--- a/infrastructure/modules/link/cloudwatch.tf
+++ b/infrastructure/modules/link/cloudwatch.tf
@@ -1,0 +1,102 @@
+resource "aws_cloudwatch_event_rule" "log_notification" {
+  name          = "${var.app}-${var.environment}-log-notification"
+  description   = "Watch CloudTrail logs for task definition registrations."
+  is_enabled    = true
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.ecs"
+  ],
+  "detail-type": [
+    "AWS API Call via CloudTrail"
+  ],
+  "detail": {
+    "eventSource": [
+      "ecs.amazonaws.com"
+    ],
+    "eventName": [
+      "RegisterTaskDefinition"
+    ]
+  }
+}
+PATTERN
+
+}
+
+resource "aws_cloudwatch_event_target" "log-event" {
+  rule      = "${aws_cloudwatch_event_rule.log_notification.name}"
+  target_id = "${aws_cloudwatch_event_rule.log_notification.name}"
+  arn       = "arn:aws:events:${var.region}:${var.portal_account_id}:event-bus/default"
+  role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.app}-${var.environment}"
+}
+
+resource "aws_cloudwatch_event_rule" "task_notification" {
+  name        = "${var.app}-${var.environment}-task-notification"
+  description = "Watch for task status changes in ECS."
+  is_enabled  = true
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.ecs"
+  ],
+  "detail-type": [
+    "ECS Task State Change"
+  ]
+}
+PATTERN
+
+}
+
+resource "aws_cloudwatch_event_target" "task-event" {
+  rule      = "${aws_cloudwatch_event_rule.task_notification.name}"
+  target_id = "${aws_cloudwatch_event_rule.task_notification.name}"
+  arn       = "arn:aws:events:${var.region}:${var.portal_account_id}:event-bus/default"
+  role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.app}-${var.environment}"
+}
+
+resource "aws_cloudwatch_event_rule" "lambda_notification" {
+  name        = "${var.app}-${var.environment}-lambda-notification"
+  description = "Watch for lambda events."
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.lambda"
+  ]
+}
+PATTERN
+
+}
+
+resource "aws_cloudwatch_event_target" "lambda-event" {
+  rule      = "${aws_cloudwatch_event_rule.lambda_notification.name}"
+  target_id = "${aws_cloudwatch_event_rule.lambda_notification.name}"
+  arn       = "arn:aws:events:${var.region}:${var.portal_account_id}:event-bus/default"
+  role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.app}-${var.environment}"
+}
+
+resource "aws_sns_topic" "alarms" {
+  name = "${var.app}-${var.environment}-alarms"
+
+  delivery_policy = <<EOF
+{
+  "http": {
+    "defaultHealthyRetryPolicy": {
+      "minDelayTarget": 20,
+      "maxDelayTarget": 20,
+      "numRetries": 3,
+      "numMaxDelayRetries": 0,
+      "numNoDelayRetries": 0,
+      "numMinDelayRetries": 0,
+      "backoffFunction": "linear"
+    },
+    "disableSubscriptionOverrides": false,
+    "defaultThrottlePolicy": {
+      "maxReceivesPerSecond": 1
+    }
+  }
+}
+EOF
+
+}

--- a/infrastructure/modules/link/variables.tf
+++ b/infrastructure/modules/link/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "app" {}
+
+variable "environment" {}
+
+variable "portal_account_id" {}

--- a/vue/pages/app/index.html
+++ b/vue/pages/app/index.html
@@ -210,14 +210,26 @@
                               </div>
                             </div>
                         </div>
-                        <div v-if="app.type == 'service' || app.type == 'scheduled-task'" class="field is-horizontal">
+                        <div class="field is-horizontal">
                             <div class="field-label is-normal">
-                              <label class="label">Cluster</label>
+                              <label class="label">Role (ARN)</label>
                             </div>
                             <div class="field-body">
                               <div class="field">
                                 <p class="control">
-                                  <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.cluster" title="The cluster name containing the service.">
+                                  <input class="input repo" :disabled="!i.claims['edit'] && !user.admin" type="text"  v-model="i.role" title="The AWS role arn that has permission to manage this instance.">
+                                </p>
+                              </div>
+                            </div>
+                        </div>
+                        <div v-if="app.type == 'service' || app.type == 'scheduled-task'" class="field is-horizontal">
+                            <div class="field-label is-normal">
+                              <label class="label">Cluster (ARN)</label>
+                            </div>
+                            <div class="field-body">
+                              <div class="field">
+                                <p class="control">
+                                  <input class="input repo" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.cluster" title="The cluster ARN for the service.">
                                 </p>
                               </div>
                             </div>
@@ -229,8 +241,20 @@
                             <div class="field-body">
                               <div class="field">
                                 <p class="control">
-                                  <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.service" title="The service name containing any running tasks.">
+                                  <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.service" title="The service name for the tasks.">
                                 </p>
+                              </div>
+                            </div>
+                        </div>
+                        <div v-if="app.type == 'service' || app.type == 'scheduled-task'" class="field is-horizontal">
+                            <div class="field-label is-normal">
+                              <label class="label">Task Definition Family</label>
+                            </div>
+                            <div class="field-body">
+                              <div class="field">
+                                <div class="control">
+                                  <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.task.family">
+                                </div>
                               </div>
                             </div>
                         </div>
@@ -248,7 +272,7 @@
                         </div>
                         <div v-if="app.type == 'lambda'" class="field is-horizontal">
                             <div class="field-label is-normal">
-                              <label class="label">Lambda Function</label>
+                              <label class="label">Lambda Function (ARN)</label>
                             </div>
                             <div class="field-body">
                               <div class="field">
@@ -313,7 +337,7 @@
                         </div>
                         <div v-if="app.type == 's3' || app.type == 'lambda'" class="field is-horizontal">
                             <div class="field-label is-normal">
-                              <label class="label">S3 Registry Bucket</label>
+                              <label class="label">S3 Registry (Bucket)</label>
                             </div>
                             <div class="field-body">
                               <div class="field">
@@ -325,7 +349,7 @@
                         </div>
                         <div v-if="app.type == 's3' || app.type == 'lambda'" class="field is-horizontal">
                             <div class="field-label is-normal">
-                              <label class="label">S3 Registry Prefix</label>
+                              <label class="label">S3 Registry (Prefix)</label>
                             </div>
                             <div class="field-body">
                               <div class="field">
@@ -342,16 +366,28 @@
                         </div>
                         <div v-if="app.type == 'service' || app.type == 'scheduled-task'" class="field is-horizontal">
                             <div class="field-label is-normal">
-                              <label class="label">Task Definition Family</label>
+                              <label class="label">ECR Registry (URI)</label>
                             </div>
                             <div class="field-body">
                               <div class="field">
-                                <div class="control">
-                                  <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.task.family">
-                                </div>
+                                <p class="control">
+                                  <input class="input repo" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.repository" placeholder="{ACCOUNT}.dkr.ecr.{REGION}}.amazonaws.com/{REPOSITORY}:VERSION.BUILD" title="The ECR repository that is considered when displaying deployable versions.">
+                                </p>
                               </div>
                             </div>
-                        </div>
+                          </div>
+                          <div class="field is-horizontal">
+                            <div class="field-label is-normal">
+                              <label class="label">Registry Role (ARN)</label>
+                            </div>
+                            <div class="field-body">
+                              <div class="field">
+                                <p class="control">
+                                  <input class="input repo" :disabled="!i.claims['edit'] && !user.admin" type="text"  v-model="i.repositoryRole" title="The AWS role arn that has permission to the registry.">
+                                </p>
+                              </div>
+                            </div>
+                          </div>
                         <div v-if="app.type != 's3'" class="field is-horizontal">
                             <div class="field-label is-normal">
                               <label class="label">
@@ -385,21 +421,9 @@
                               </div>
                             </div>
                         </div>
-                        <div v-if="app.type == 'service' || app.type == 'scheduled-task'" class="field is-horizontal">
-                            <div class="field-label is-normal">
-                              <label class="label">ECR Repository</label>
-                            </div>
-                            <div class="field-body">
-                              <div class="field">
-                                <p class="control">
-                                  <input class="input repo" :disabled="!i.claims['edit'] && !user.admin" type="text" v-model="i.repository" placeholder="{ACCOUNT}.dkr.ecr.{REGION}}.amazonaws.com/{REPOSITORY}:VERSION.BUILD" title="The ECR repository that is considered when displaying deployable versions.">
-                                </p>
-                              </div>
-                            </div>
-                        </div>
                         <div class="field is-horizontal">
                             <div class="field-label is-normal">
-                              <label class="label">Deploy From (default)</label>
+                              <label class="label">Deploy From</label>
                             </div>
                             <div class="field-body">
                               <div class="field">


### PR DESCRIPTION
To promote better security and support environment separation best practices, monitoring and deployments should be able to assume different AWS roles enabling role based deployments in a single or multiple AWS account architecture. 