### PR TITLE
Terraform fixes

### DIFF
--- a/infrastructure/modules/portal/ecs-event-stream.tf
+++ b/infrastructure/modules/portal/ecs-event-stream.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "ecs_event_stream" {
   filename         = data.archive_file.lambda_zip.output_path
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   handler          = "index.handler"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
   tags             = var.tags
 }
 

--- a/infrastructure/portals/prod/main.tf
+++ b/infrastructure/portals/prod/main.tf
@@ -58,6 +58,6 @@ output "kms_key_id" {
 # SQS queue watched for s3 deployment 
 # changes when updating the portal ui.
 output "s3_change_queue" {
-  value = module.dev.s3_change_queue
+  value = module.env.s3_change_queue
 }
 


### PR DESCRIPTION
* Updated ecs event stream lambda to use node 12.x runtime
* Fixed invalid module name in the s3 change queue

Addresses issues #9 and #10 