### PR TITLE
replacing card revision with build

### DIFF
--- a/component/app/model_instance.go
+++ b/component/app/model_instance.go
@@ -36,6 +36,7 @@ type InstanceView struct {
 	FormattedVersion string `json:"formattedVersion"`
 	Version          string `json:"version"`
 	Revision         int64  `json:"revision"`
+	Build            string `json:"build"`
 
 	Containers []ContainerView `json:"containers"`
 	Deployment DeploymentView  `json:"deployment"`
@@ -289,6 +290,7 @@ func (i Instance) ToView(name string, appClaim user.AppClaim) InstanceView {
 		}
 	}
 
+	v.Build = i.Task.Definition.Build
 	v.Revision = i.Task.Definition.Revision
 	v.DesiredCount = i.Task.DesiredCount
 

--- a/vue/pages/apps/index.html
+++ b/vue/pages/apps/index.html
@@ -85,7 +85,9 @@
                             v-on:dragover.prevent="dragOver($event, inst)" 
                             v-on:drop="dragDrop($event, app, inst)" 
                             v-bind:class="statusClass(app, inst)" class="cell is-size-6 has-text-weight-bold">
-                            {{ inst.version }} <span v-if="inst.revision > 0">({{ inst.revision }})</span>
+                            {{ inst.formattedVersion }} 
+                            <span v-if="inst.revision > 0">({{ inst.revision }})</span>
+
                             <div class="is-pulled-right">
                                 <button v-if="actions(app.type, inst).restart && inst.isRunning" :disabled="!inst.claims.scale" title="restart instance" class="button" @click.stop.prevent="selected = { app: app, instance: inst }; modal.confirm = { show: true, code: inst.deployCode, message: 'Restart all running tasks for ' + inst.name + '.', action: restartInstance }">
                                     <span class="icon is-small">
@@ -161,12 +163,14 @@
                                 v-on:dragleave="dragLeave($event, app, inst)" 
                                 v-on:dragover.prevent="dragOver($event, inst)" 
                                 v-on:drop="dragDrop($event, app, inst)" 
-                                v-bind:class="statusClass(app, inst)">
-
+                                v-bind:class="statusClass(app, inst)"
+                                :title="formatDetails(inst.formattedVersion, inst.revision)">
                                 <div class="text">
-                                    <p class="is-size-6 has-text-weight-bold is-marginless" :title="inst.version">{{ formatVersion(inst.version) }}</p>
-                                    <p class="is-size-7"><span v-if="inst.revision > 0">revision {{ inst.revision }}</span></p>
+                                    <p class="is-size-6 has-text-weight-bold is-marginless">{{ formatVersion(inst.version) }}</p>
 
+                                    <div class="is-size-7" v-if="inst.build > 0">build {{ inst.build }}</div> 
+                                    <p></p>
+                                   
                                     <div v-if="inst.deployment.isPending">
                                         <progress class="progress is-small" v-bind:class="{'is-secondary': inst.deployment.isPending}" max="100">15%</progress>
                                     </div>

--- a/vue/pages/apps/index.js
+++ b/vue/pages/apps/index.js
@@ -147,6 +147,9 @@ includeTenplates().then(() => {
 
                 return version
             },
+            formatDetails(version, revision) {
+                return `${version} (revision ${revision})`
+            },
             hasEditPermission(app) {
                 if (!this.user) {
                     return false


### PR DESCRIPTION
The build number has more importance to deployment than the revision number in my opinion. I propose the build number take the place of the revision number on the card. The revision number would only be displayed when hovering over a card.
<img width="202" alt="Screen Shot 2020-03-10 at 4 02 00 PM" src="https://user-images.githubusercontent.com/20706371/76354843-9a121600-62e9-11ea-8971-e67972924d4d.png">
