### PR TITLE
Limit the S3 SQS change queue to only receive messages from specific AWS accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Authorized users can perform drag-n-drop deployments without understanding the t
 ### Goals ###
 
 * Create portal to deploy and monitor AWS resources
+* Make projects searchable for quick access to details, versions, and documentation
 * Enable consitent application versioning across multiple AWS resource types
 * Secure deployments by application and/or environment
 * Allow simple drag-n-drop deployments
 * Provide high level environment resource notifications and troubleshooting
-* Make projects searchable for quick access to details, versions, and documentation
 * Improve resource monitoring and interaction for integration partners
-* Support authetication with any OAuth2 API
-* Enable deployment workflow innovation (avoid third-party timelines)
+* Support authentication with any OAuth2 API
+* Enable deployment workflow innovation (avoid third-party timelines and costs)
 * Centralize navigation to project resources by linking to scrum boards, config tools, and project documentation
 * Assist projects transitioning from [Harbor UI](https://github.com/turnerlabs/harbor-ui)
 

--- a/infrastructure/modules/portal/sqs.tf
+++ b/infrastructure/modules/portal/sqs.tf
@@ -93,7 +93,7 @@ resource "aws_sqs_queue" "s3_queue" {
   "Statement": [
     {
       "Effect": "Allow",
-      "Principal": "*",
+      "Principal": { "AWS": ${jsonencode(concat(data.template_file.linked_account_ids.*.rendered, ["${data.aws_caller_identity.current.account_id}"]))} },
       "Action": "sqs:SendMessage",
       "Resource": "arn:aws:sqs:*:*:${var.app}-${var.environment}-s3-queue",
       "Condition": {
@@ -110,5 +110,15 @@ POLICY
 # changes when updating the portal ui.
 output "s3_change_queue" {
   value = aws_sqs_queue.s3_queue.name
+}
+
+//render dynamic list of linked account ids
+data "template_file" "linked_account_ids" {
+  count    = length(var.linked_account_ids)
+  template = "$${account}"
+
+  vars = {
+    account = var.linked_account_ids[count.index]
+  }
 }
 


### PR DESCRIPTION
Only allow AWS accounts that are apart of the udeploy ecosystem to publish messages to the portal's S3 SQS change queue for security purposes.