### PR TITLE
Add new feature to s3 deployment to allow user to inform distribution…

### DIFF
--- a/component/app/copy.go
+++ b/component/app/copy.go
@@ -78,7 +78,7 @@ func (i Instance) Copy() Instance {
 		S3ConfigKey:      i.S3ConfigKey,
 		S3RegistryBucket: i.S3RegistryBucket,
 		S3RegistryPrefix: i.S3RegistryPrefix,
-		CloudFrontId:     i.CloudFrontId,
+		CloudFrontID:     i.CloudFrontID,
 		DeployCode:       i.DeployCode,
 		AutoPropagate:    i.AutoPropagate,
 		AutoScale:        i.AutoScale,

--- a/component/app/copy.go
+++ b/component/app/copy.go
@@ -78,6 +78,7 @@ func (i Instance) Copy() Instance {
 		S3ConfigKey:      i.S3ConfigKey,
 		S3RegistryBucket: i.S3RegistryBucket,
 		S3RegistryPrefix: i.S3RegistryPrefix,
+		CloudFrontId:     i.CloudFrontId,
 		DeployCode:       i.DeployCode,
 		AutoPropagate:    i.AutoPropagate,
 		AutoScale:        i.AutoScale,

--- a/component/app/model_instance.go
+++ b/component/app/model_instance.go
@@ -25,7 +25,7 @@ type InstanceView struct {
 	S3Prefix         string `json:"s3Prefix,omitempty"`
 	S3RegistryBucket string `json:"s3RegistryBucket,omitempty"`
 	S3RegistryPrefix string `json:"s3RegistryPrefix,omitempty"`
-	CloudFrontId     string `json:"cloudFrontId,omitempty"`
+	CloudFrontID     string `json:"cloudFrontId,omitempty"`
 
 	Repository     string   `json:"repository,omitempty"`
 	RepositoryRole string   `json:"repositoryRole,omitempty"`
@@ -90,7 +90,7 @@ type Instance struct {
 	S3Prefix         string `json:"s3Prefix,omitempty" bson:"s3Prefix"`
 	S3RegistryBucket string `json:"s3RegistryBucket,omitempty" bson:"s3RegistryBucket"`
 	S3RegistryPrefix string `json:"s3RegistryPrefix,omitempty" bson:"s3RegistryPrefix"`
-	CloudFrontId     string `json:"cloudFrontId,omitempty" bson:"cloudFrontId"`
+	CloudFrontID     string `json:"cloudFrontId,omitempty" bson:"cloudFrontId"`
 
 	Repository     string `json:"repository,omitempty" bson:"repository"`
 	RepositoryRole string `json:"repositoryRole,omitempty" bson:"repositoryRole"`
@@ -202,7 +202,7 @@ func (v InstanceView) ToBusiness() Instance {
 		S3ConfigKey:      v.S3ConfigKey,
 		S3RegistryBucket: v.S3RegistryBucket,
 		S3RegistryPrefix: v.S3RegistryPrefix,
-		CloudFrontId:     v.CloudFrontId,
+		CloudFrontID:     v.CloudFrontID,
 		DeployCode:       v.DeployCode,
 		AutoPropagate:    v.AutoPropagate,
 		AutoScale:        v.AutoScale,
@@ -250,7 +250,7 @@ func (i Instance) ToView(name string, appClaim user.AppClaim) InstanceView {
 		S3ConfigKey:      i.S3ConfigKey,
 		S3RegistryBucket: i.S3RegistryBucket,
 		S3RegistryPrefix: i.S3RegistryPrefix,
-		CloudFrontId:     i.CloudFrontId,
+		CloudFrontID:     i.CloudFrontID,
 		Repository:       i.Repository,
 		RepositoryRole:   i.RepositoryRole,
 		DeployCode:       i.DeployCode,

--- a/component/app/model_instance.go
+++ b/component/app/model_instance.go
@@ -25,6 +25,7 @@ type InstanceView struct {
 	S3Prefix         string `json:"s3Prefix,omitempty"`
 	S3RegistryBucket string `json:"s3RegistryBucket,omitempty"`
 	S3RegistryPrefix string `json:"s3RegistryPrefix,omitempty"`
+	CloudFrontId     string `json:"cloudFrontId,omitempty"`
 
 	Repository     string   `json:"repository,omitempty"`
 	RepositoryRole string   `json:"repositoryRole,omitempty"`
@@ -89,6 +90,7 @@ type Instance struct {
 	S3Prefix         string `json:"s3Prefix,omitempty" bson:"s3Prefix"`
 	S3RegistryBucket string `json:"s3RegistryBucket,omitempty" bson:"s3RegistryBucket"`
 	S3RegistryPrefix string `json:"s3RegistryPrefix,omitempty" bson:"s3RegistryPrefix"`
+	CloudFrontId     string `json:"cloudFrontId,omitempty" bson:"cloudFrontId"`
 
 	Repository     string `json:"repository,omitempty" bson:"repository"`
 	RepositoryRole string `json:"repositoryRole,omitempty" bson:"repositoryRole"`
@@ -200,6 +202,7 @@ func (v InstanceView) ToBusiness() Instance {
 		S3ConfigKey:      v.S3ConfigKey,
 		S3RegistryBucket: v.S3RegistryBucket,
 		S3RegistryPrefix: v.S3RegistryPrefix,
+		CloudFrontId:     v.CloudFrontId,
 		DeployCode:       v.DeployCode,
 		AutoPropagate:    v.AutoPropagate,
 		AutoScale:        v.AutoScale,
@@ -247,6 +250,7 @@ func (i Instance) ToView(name string, appClaim user.AppClaim) InstanceView {
 		S3ConfigKey:      i.S3ConfigKey,
 		S3RegistryBucket: i.S3RegistryBucket,
 		S3RegistryPrefix: i.S3RegistryPrefix,
+		CloudFrontId:     i.CloudFrontId,
 		Repository:       i.Repository,
 		RepositoryRole:   i.RepositoryRole,
 		DeployCode:       i.DeployCode,

--- a/infrastructure/modules/portal/role.tf
+++ b/infrastructure/modules/portal/role.tf
@@ -85,6 +85,9 @@ data "aws_iam_policy_document" "app_policy" {
       "s3:DeleteObject",
       "s3:ListBucket",
       "sts:AssumeRole",
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+      "cloudfront:ListInvalidations",      
     ]
 
     resources = [

--- a/vue/pages/app/index.html
+++ b/vue/pages/app/index.html
@@ -404,6 +404,19 @@
                               </div>
                             </div>
                         </div>
+                        <div v-if="app.type == 's3'" class="field is-horizontal">
+                          <div class="field-label is-normal">
+                            <label class="label">CloudFront (ID)</label>
+                          </div>
+                          <div class="field-body">
+                            <div class="field">
+                              <p class="control">
+                                <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text"  v-model="i.cloudFrontId" title="The CloudFront Distribution ID that serves your static s3 bucket on a cdn.">
+                                <label class="help">Specify the CloudFront Distribution id that will be used to create an invalidation object upon deployment.</label>
+                              </p>
+                            </div>
+                          </div>
+                        </div>                         
                         <div v-if="app.type == 'service' || app.type == 'scheduled-task'" class="field is-horizontal">
                             <div class="field-label is-normal">
                               <label class="label">ECR Registry (URI)</label>
@@ -427,7 +440,7 @@
                                 </p>
                               </div>
                             </div>
-                          </div>
+                          </div>                         
                         <div class="field is-horizontal">
                             <div class="field-label is-normal">
                               <label class="label">

--- a/vue/pages/app/index.html
+++ b/vue/pages/app/index.html
@@ -406,13 +406,13 @@
                         </div>
                         <div v-if="app.type == 's3'" class="field is-horizontal">
                           <div class="field-label is-normal">
-                            <label class="label">CloudFront (ID)</label>
+                            <label class="label">CloudFront ID</label>
                           </div>
                           <div class="field-body">
                             <div class="field">
                               <p class="control">
-                                <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text"  v-model="i.cloudFrontId" title="The CloudFront Distribution ID that serves your static s3 bucket on a cdn.">
-                                <label class="help">Specify the CloudFront Distribution id that will be used to create an invalidation object upon deployment.</label>
+                                <input class="input name" :disabled="!i.claims['edit'] && !user.admin" type="text"  v-model="i.cloudFrontId" title="The CloudFront Distribution ID that serves a static s3 bucket on a CDN.">
+                                <label class="help">Distribution ID that is used to invalidate the cache after a deployment.</label>
                               </p>
                             </div>
                           </div>
@@ -440,7 +440,7 @@
                                 </p>
                               </div>
                             </div>
-                          </div>                         
+                          </div>
                         <div class="field is-horizontal">
                             <div class="field-label is-normal">
                               <label class="label">


### PR DESCRIPTION
Add new feature to s3 deployment to allow user to inform distribution id used for cache invalidation during deployment:

![image](https://user-images.githubusercontent.com/34108201/81412386-c4c5f280-9111-11ea-9907-c82e431e7f1d.png)

![image](https://user-images.githubusercontent.com/34108201/81412778-5c2b4580-9112-11ea-837b-d584650edfac.png)
