### PR TITLE
Stop portal from failing when ECS tasks fail to start.

### DIFF
--- a/component/integration/aws/service/populate.go
+++ b/component/integration/aws/service/populate.go
@@ -211,9 +211,17 @@ func getServiceError(tasks []*ecs.Task, expiration time.Duration) (int, error) {
 		if t.StopCode != nil && t.StoppedReason != nil {
 			if *t.StopCode != ecs.TaskStopCodeUserInitiated {
 
-				if time.Now().Sub(*t.ExecutionStoppedAt) < expiration {
-					reason = errors.New(*t.StoppedReason)
-					count++
+				switch *t.StopCode {
+				case ecs.TaskStopCodeTaskFailedToStart:
+					if time.Now().Sub(*t.CreatedAt) < expiration {
+						reason = errors.New(*t.StoppedReason)
+						count++
+					}
+				default:
+					if time.Now().Sub(*t.ExecutionStoppedAt) < expiration {
+						reason = errors.New(*t.StoppedReason)
+						count++
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Modification

When a failed ECS task could not start compare the `CreatedAt` field instead of the `ExecutionStoppedAt` field with the task expiration constant to avoid a nil reference error and causes the portal to fail.

This allows tasks that fail when running and fail when trying to start to be considered when determining the services current state.