### PR TITLE
Moving CICD build to github containers

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,51 +1,61 @@
-name: BuildNPublish
+name: BuildNPublishGH
 on:
   push:
     tags:
     - 'v[0-9]+.[0-9]+.[0-9]+-[a-z]+'
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
 jobs:
- 
   build:
-    name: Build
+
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-    - name: Log Build Number
-      run : echo 'Build ${{ github.run_number }}'
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
 
-    - name: Check out Code 
-      uses: actions/checkout@v2
-     
-    - name: Run Tests
-      env:
-        MISSING_ENV_OK: true
-      run: go test ./... 
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set docker image
-      env:
-        REPO: quay.io/turner/udeploy:${GITHUB_REF##*/}.${{ github.run_number }}
-      run: |
-        echo "export IMAGE=$REPO" >> ./env
-        cat ./env
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,enable=true,prefix=${{ github.ref_name }},value=.,suffix=${{ github.run_number }}
 
-    - name: Build image
-      uses: turnerlabs/fargate-cicd-action@master
-      with:
-        args: . ./env; docker build -t $IMAGE --build-arg version=${GITHUB_REF##*/}.${{ github.run_number }} .
-    
-    - name: Log in to Quay
-      uses: turnerlabs/fargate-cicd-action@master
-      env:
-        QUAY_USER: ${{ secrets.QUAY_USER }}
-        QUAY_PASS: ${{ secrets.QUAY_PASS }}
-      with:
-        args: docker login -u="$QUAY_USER" -p="$QUAY_PASS" quay.io
-    
-    - name: Push image to Quay
-      uses: turnerlabs/fargate-cicd-action@master
-      with:
-        args: . ./env; docker push $IMAGE
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      # add linux/arm64, to platforms to get ARM support
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          no-cache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /deploy
 RUN sed -i'.av' -E "s/\?auto-version=[0-9]+/\?auto-version=$RANDOM/g" vue/pages/**/*.html
 RUN find vue/pages -name '*.av' -delete
 
+RUN MISSING_ENV_OK=true go test ./...
+
 RUN go build -ldflags '-X main.version='$version
 
 CMD ./udeploy


### PR DESCRIPTION
In order to move this container away from Quay.io, I have updated the CICD script using our new preferred method to push to the Github container registry. I've also moved the unit test step into the container creation. 

There are a few other docker improvements I have in the works, but I wanted this to be a simpler push of the existing version without making any changes that could require a full regression test.